### PR TITLE
v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,12 @@ Clicking on a category takes you to the api document.
       <td>updateTimeline(registrationId:String, timelineId:Number, data:Object)</td>
       <td>Update timeline</td>
     </tr>
+
+    <tr>
+      <td rowspan="2">legacy</td>
+      <td>legacy(options:Object)</td>
+      <td>The bridge of old APIs</td>
+    </tr>
   </tbody>
 </table>
 

--- a/lib/apis/index.js
+++ b/lib/apis/index.js
@@ -7,6 +7,7 @@ const teams = require('./teams');
 const usages = require('./usages');
 const users = require('./users');
 const timelines = require('./timelines');
+const legacy = require('./legacy');
 
 const apis = {
   bills,
@@ -18,6 +19,7 @@ const apis = {
   usages,
   users,
   timelines,
-}
+  legacy,
+};
 
 module.exports = apis;

--- a/lib/apis/legacy/index.js
+++ b/lib/apis/legacy/index.js
@@ -1,0 +1,49 @@
+const { createAxiosError } = require('../../utils');
+
+const allowedVersions = ['1.1', '1.2'];
+const allowedMethods = ['get', 'post', 'put'];
+
+function isAllowedVersion(path) {
+  return allowedVersions.some(version => path.startsWith(version) || path.startsWith(`/${version}`));
+}
+
+function isAllowedMethod(method) {
+  return allowedMethods.some(allowedMethod => method === allowedMethod || method === allowedMethod.toUpperCase());
+}
+
+function legacy(options = {}) {
+  const {
+    path = '',
+    method = 'get',
+    data = {},
+    params = {},
+  } = options;
+  const requestOptions = {
+    url: path,
+    method,
+    params,
+    data,
+  }
+
+  if (!isAllowedVersion(path)) {
+    const error = createAxiosError(
+      400,
+      'InvalidAPIVersion',
+      'The API version in path is not supported'
+    );
+    return Promise.reject(error);
+  }
+
+  if (!isAllowedMethod(method)) {
+    const error = createAxiosError(
+      405,
+      'MethodNotAllowed',
+      'The HTTP method should be one of \'get\', \'post\', \'put\''
+    );
+    return Promise.reject(error);
+  }
+
+  return this.request(requestOptions);
+}
+
+module.exports.legacy = legacy;

--- a/lib/client.js
+++ b/lib/client.js
@@ -6,6 +6,7 @@ const Buffer = require('buffer/').Buffer;
 const constants = require('./constants');
 const endpoints = require('./endpoints');
 const apis = require('./apis');
+const { createAxiosError } = require('./utils');
 
 class EnerTalkAPIClient extends axios.Axios {
   static transformToAxiosConfig(config, options) {
@@ -162,16 +163,9 @@ class EnerTalkAPIClient extends axios.Axios {
       checkRefreshInterval = setInterval(() => {
         checkCount += 1;
 
-        if (checkCount > 10) {
+        if (checkCount > 5) {
           clearInterval(checkRefreshInterval);
-          return reject({
-            response: {
-              data: {
-                code: 403,
-                type: 'TokenRefreshError'
-              },
-            },
-          });
+          return reject(createAxiosError(401, 'TokenRefreshError'));
         }
 
         if (!this.tokenRefreshing) {

--- a/lib/client.js
+++ b/lib/client.js
@@ -60,9 +60,9 @@ class EnerTalkAPIClient extends axios.Axios {
           .then((tokenObject) => this.updateToken(tokenObject))
           .then((tokenObject) => this.syncWithCaller(tokenObject))
           .then(() => this.retryFailedRequest(failedRequestConfig));
-      } else {
-        return Promise.reject(error);
       }
+
+      return Promise.reject(error);
     });
 
     if (options instanceof Array) {
@@ -164,7 +164,14 @@ class EnerTalkAPIClient extends axios.Axios {
 
         if (checkCount > 10) {
           clearInterval(checkRefreshInterval);
-          return reject();
+          return reject({
+            response: {
+              data: {
+                code: 403,
+                type: 'TokenRefreshError'
+              },
+            },
+          });
         }
 
         if (!this.tokenRefreshing) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,15 @@
+function createAxiosError(code = 500, type = 'InternalError', message = null) {
+  return {
+    response: {
+      data: {
+        code,
+        type,
+        message,
+      },
+    },
+  };
+}
+
+module.exports = {
+  createAxiosError,
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enertalk-api-client",
-  "version": "0.4.8",
+  "version": "0.5.0",
   "main": "lib/client.js",
   "repository": {
     "url": "https://github.com/encoredincubator/enertalk-api-client.git",


### PR DESCRIPTION
### Changes
- Reject with an error which indicates token refresh failed.

  - It occurs 5 seconds after the token refresh request
  - Example:
```js
const api = new EnerTalkAPI({ ... });

// It applies to all APIs
api.getUser().catch((error) => {
  const { response: { data } } = error;
  const tokenRefreshFailed = data.code === 401 && data.type === 'TokenRefreshError';

  if (tokenRefreshFailed) {
    // Do a client specific handling
  }
});
```

- Add `legacy` method to use old APIs(1.1, 1.2)

  - Example:
```js
const api = new EnerTalkAPI({ ... });

api.legacy({
  path: '/1.2/me',
  method: 'get', // default. 'get', 'post', and 'put' methods are allowed
  params: {}  // querystring for 'get' method
  data: {} // body object for 'post' or 'put'
})
.then(...)
.catch(...);
```