### PR TITLE
Add Pre-commit Hook

### DIFF
--- a/build/apis/push/index.js
+++ b/build/apis/push/index.js
@@ -14,6 +14,9 @@ var push = {
   },
   getPushStates: function getPushStates() {
     return this.get(endpoint.listPushInfoInSite);
+  },
+  resetPushToken: function resetPushToken() {
+    return this.delete(endpoint.pushInfo, params || {});
   }
 };
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^0.15.3",
-    "buffer": "^5.0.3"
+    "buffer": "^5.0.3",
+    "husky": "^0.14.3"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",
@@ -25,6 +26,7 @@
     "moxios": "^0.3.0"
   },
   "scripts": {
+    "prepush": "yarn build && git add . && git commit --amend --no-edit",
     "test": "jest --watch",
     "build": "babel lib --out-dir build --ignore __tests__"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "moxios": "^0.3.0"
   },
   "scripts": {
-    "prepush": "yarn build && git add . && git commit --amend --no-edit",
+    "precommit": "yarn build && git add .",
     "test": "jest --watch",
     "build": "babel lib --out-dir build --ignore __tests__"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,14 @@ http-signature@~1.1.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
+husky@^0.14.3:
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
+  dependencies:
+    is-ci "^1.0.10"
+    normalize-path "^1.0.0"
+    strip-indent "^2.0.0"
+
 iconv-lite@0.4.13:
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.13.tgz#1f88aba4ab0b1508e8312acc39345f36e992e2f2"
@@ -2388,6 +2396,10 @@ normalize-package-data@^2.3.2:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
+normalize-path@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
+
 normalize-path@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.0.1.tgz#47886ac1662760d4261b7d979d241709d3ce3f7a"
@@ -3075,6 +3087,10 @@ strip-bom@^2.0.0:
 strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
+
+strip-indent@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
It's required to run the `yarn build` command before push to remote.
By using [husky](https://github.com/typicode/husky) tool, precommit command has been added.