### PR TITLE
Fix wrong endpoint calls in the site-based timeline API

### DIFF
--- a/build/apis/timelines/index.js
+++ b/build/apis/timelines/index.js
@@ -10,10 +10,10 @@ var timelines = {
     return this.put(endpoint.timeline(registrationId, timelineId), data || {});
   },
   timelinesBySite: function timelinesBySite(siteId, params) {
-    return this.get(endpoint.timelines(siteId), { params: params });
+    return this.get(endpoint.timelinesBySite(siteId), { params: params });
   },
   updateTimelineBySite: function updateTimelineBySite(siteId, timelineId, data) {
-    return this.put(endpoint.timeline(siteId, timelineId), data || {});
+    return this.put(endpoint.timelineBySite(siteId, timelineId), data || {});
   }
 };
 

--- a/lib/apis/timelines/index.js
+++ b/lib/apis/timelines/index.js
@@ -8,10 +8,10 @@ const timelines = {
     return this.put(endpoint.timeline(registrationId, timelineId), data || {});
   },
   timelinesBySite(siteId, params) {
-    return this.get(endpoint.timelines(siteId), { params });
+    return this.get(endpoint.timelinesBySite(siteId), { params });
   },
   updateTimelineBySite(siteId, timelineId, data) {
-    return this.put(endpoint.timeline(siteId, timelineId), data || {});
+    return this.put(endpoint.timelineBySite(siteId, timelineId), data || {});
   },
 };
 


### PR DESCRIPTION
It was calling device-based APIs internally.